### PR TITLE
Fixing the placement of the alert banner UCLAIAM-56

### DIFF
--- a/src/assets/scss/components/_mfa.scss
+++ b/src/assets/scss/components/_mfa.scss
@@ -72,9 +72,10 @@ fieldgroup.inline {
 }
 
 @mixin notification-banner($background: $ucla-blue, $color: $white) {
-  position: absolute;
+  position: fixed;
   top: 0;
-  right: 0;
+  left: 50%;
+  transform: translateX(-50%);
   @include grid-row();
   width: 100%;
   height: $global-spacing * 3;


### PR DESCRIPTION
### Problem ###
The placement of the banner was off for desktop views. It also was only `display: absolute`, seems as though it should be `fixed`. Not sure if that is the intended result though. 

### Solution ###
Made the alert banner `display: fixed`. Positioned 50% left with a `translateX(-50%)` to always be centered.

![screen-shot 2017-01-09 at 11 24 58 am](https://cloud.githubusercontent.com/assets/1024727/21779950/9d97187c-d65e-11e6-917d-d4633174d04a.png)
![screen-shot 2017-01-09 at 11 24 48 am](https://cloud.githubusercontent.com/assets/1024727/21779951/9d97c0ce-d65e-11e6-8dd2-1ebdd4def1dd.png)
